### PR TITLE
Adding a delay to the -a command flag

### DIFF
--- a/kano-screenshot.c
+++ b/kano-screenshot.c
@@ -317,10 +317,9 @@ int main(int argc, char *argv[])
 	    kprintf ("Could not find application name: '%s'\n", appname);
 	    exit (EXIT_FAILURE);
 	  }
-	  else {
-	    kprintf ("Cropping application name '%s' (x=%d, y=%d, width=%d, height=%d)\n",
-		     appname, cropx, cropy, cropwidth, cropheight);
-	  }
+
+	  kprintf ("Cropping application name '%s' (x=%d, y=%d, width=%d, height=%d)\n",
+		   appname, cropx, cropy, cropwidth, cropheight);
 	  break;
 
 	case 'c':


### PR DESCRIPTION
- When requesting an application name, accept the delay parameter
  so kano-screenshot waits up to delay seconds for the application to show up,
  or give up with rc failure
