### PR TITLE
Fixing corrupted images if using -w param

### DIFF
--- a/kano-screenshot.c
+++ b/kano-screenshot.c
@@ -639,8 +639,6 @@ int main(int argc, char *argv[])
 	}
       }
 
-    pitch = bytesPerPixel * ALIGN_TO_16(width);
-
     //-------------------------------------------------------------------
 
     png_structp pngPtr = png_create_write_struct(PNG_LIBPNG_VER_STRING,


### PR DESCRIPTION
- The image's pitch value should be computed
  according to overall screen size.
