### PR TITLE
Fixing eventual hang if several DispmanX apps were running

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-screenshot (1.2-1) unstable; urgency=low
+
+  * Fixed eventual hang if several DispmanX apps were running
+
+ -- Team Kano <dev@kano.me>  Mon, 11 Apr 2016 17:10:03 +0100
+
 kano-screenshot (1.1-1) unstable; urgency=low
 
   * Initial release.


### PR DESCRIPTION
 * The problem was that whilst kano-screenshot had a Dispmanx connection,
   popen was used to call "vcgencmd" to query the screen rotation flag,
   hence opening an additional dispmanx connection.

 * Fixed by calling the VideoCode API instead to get the rotation status,
   hence sharing the same Dispmanx connection.

cc @Ealdwulf 